### PR TITLE
Update dependencies

### DIFF
--- a/ComponentInterpolator.js
+++ b/ComponentInterpolator.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var invariant = require('react/lib/invariant');
+var invariant = require('invariant');
 var { string, object } = React.PropTypes;
 
 var WRAPPER_PATTERN = /(\*+)/;

--- a/dist/ComponentInterpolator.js
+++ b/dist/ComponentInterpolator.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var invariant = require('react/lib/invariant');
+var invariant = require('invariant');
 var $__0=     React.PropTypes,string=$__0.string,object=$__0.object;
 
 var WRAPPER_PATTERN = /(\*+)/;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18nliner",
-  "version": "0.0.12",
+  "version": "0.0.14",
   "description": "i18n made simple",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   "author": "Jon Jensen",
   "license": "ISC",
   "devDependencies": {
-    "jest-cli": "^0.2.2",
-    "jsxhint": "^0.10.0",
-    "react": "0.13.x",
+    "invariant": "^2.1.1",
+    "jest-cli": "^0.5.10",
+    "jsxhint": "^0.15.1",
+    "react": "0.14.x",
     "react-tools": "0.13.x"
   },
   "peerDependencies": {
-    "react": "0.13.x"
+    "react": "0.14.x"
   },
   "jest": {
     "scriptPreprocessor": "test_utils/preprocessor.js",
@@ -29,6 +30,6 @@
   "dependencies": {
     "i18nliner": "^0.1.5",
     "recast": "^0.10.12",
-    "through2": "^0.6.3"
+    "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
New `react-i18nliner` version depending on the `react` 0.14 version. It seems to have a breaking change with the `invariant` library.
