### PR TITLE
Fix build on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "i18n made simple",
   "main": "main.js",
   "scripts": {
-    "test": "node_modules/.bin/eslint . && node_modules/.bin/jest",
+    "test": "eslint . && jest",
     "dist": "babel -d dist ComponentInterpolator.js extensions/i18n_js.js"
   },
   "author": "Jon Jensen",


### PR DESCRIPTION
Removed the node_modules prefix when calling eslint and jest
They are not needed since these libraries are NPM dependencies and NPM knows how to invoke them
See Running tests fails on Windows #28

After applying the changes from this PR, I get this result for `npm test`:

```sh
c:\ws\react-i18nliner> npm test

> react-i18nliner@0.1.0 test c:\ws\react-i18nliner
> eslint . && jest

Using Jest CLI v12.1.1, jasmine2, babel-jest
Running 2 test suites...
 PASS  __tests__\ComponentInterpolator.test.js (1.433s)
 PASS  __tests__\preprocess.test.js (1.598s)
29 tests passed (29 total in 2 test suites, run time 3.393s)
```
